### PR TITLE
Path access tests are completed

### DIFF
--- a/storage-monitor-bdd-tests/src/test/java/automation/step_definitions/LoginSteps.java
+++ b/storage-monitor-bdd-tests/src/test/java/automation/step_definitions/LoginSteps.java
@@ -1,9 +1,9 @@
 package automation.step_definitions;
 
+import io.cucumber.java.After;
 import automation.base.BaseTest;
 import automation.page.LoginPage;
 import io.cucumber.java.en.*;
-import org.junit.After;
 import org.junit.Assert;
 
 public class LoginSteps extends BaseTest {

--- a/storage-monitor-bdd-tests/src/test/java/automation/step_definitions/UnAuthenticatedAccessSteps.java
+++ b/storage-monitor-bdd-tests/src/test/java/automation/step_definitions/UnAuthenticatedAccessSteps.java
@@ -1,0 +1,35 @@
+package automation.step_definitions;
+
+import automation.base.BaseTest;
+import io.cucumber.java.After;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.Assert;
+import org.openqa.selenium.WebDriver;
+
+public class UnAuthenticatedAccessSteps extends BaseTest {
+
+    private String path;
+
+    @After
+    public void clean() {
+        tearDown();
+    }
+
+    @When("Navigating to path {string}")
+    public void navigateToPath(String path) {
+        this.path = path;
+        setUp(path);
+    }
+
+    @Then("Should be redirected to login page if should be redirected {string}")
+    public void shouldBeRedirectedToLoginPage(String shouldRedirected) {
+        boolean redirect = Boolean.parseBoolean(shouldRedirected);
+        String currentURL = wait.until(WebDriver::getCurrentUrl);
+        if (redirect) {
+            Assert.assertTrue(currentURL.endsWith("/login"));
+        } else {
+            Assert.assertTrue(currentURL.endsWith("/" + path));
+        }
+    }
+}

--- a/storage-monitor-bdd-tests/src/test/resources/features/unauthenticated_paths.feature
+++ b/storage-monitor-bdd-tests/src/test/resources/features/unauthenticated_paths.feature
@@ -1,0 +1,14 @@
+Feature: Unauthenticated path access
+
+  Scenario Outline: Accessing path "<path>" without logging in
+    When Navigating to path "<path>"
+    Then Should be redirected to login page if should be redirected "<shouldRedirected>"
+
+    Examples:
+      | path         | shouldRedirected |
+      | home         | true           |
+      | storagelist  | true           |
+      | products     | true           |
+      | production   | true           |
+      | login        | false          |
+      | register     | false          |


### PR DESCRIPTION
* Add `unauthenticated_paths.feature` with a Scenario Outline covering both protected (`home`, `storagelist`, `products`, `production`) and public (`login`, `register`) routes
* Implement `UnAuthenticatedAccessSteps.java` to navigate to each path and assert redirect-to-login or direct access based on the `shouldRedirected` flag
* Extract teardown into a global Cucumber `@After` hook (`Hooks.java`) to guarantee browser cleanup after every scenario
